### PR TITLE
Remove "./:" from keyword characters

### DIFF
--- a/syntax/nginx.vim
+++ b/syntax/nginx.vim
@@ -5,10 +5,6 @@ if exists("b:current_syntax")
   finish
 end
 
-setlocal iskeyword+=.
-setlocal iskeyword+=/
-setlocal iskeyword+=:
-
 syn match ngxVariable '\$\w\w*'
 syn match ngxVariableBlock '\$\w\w*' contained
 syn match ngxVariableString '\$\w\w*' contained


### PR DESCRIPTION
This fixes a problem with word boundaried in nginx config files. Also see here:

http://stackoverflow.com/questions/17105272/wrong-word-boundaries-in-nginx-files-with-vim
